### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,23 @@ Follow existing patterns in the target area first; below are common defaults.
 - Make focused changes; avoid unrelated refactors.
 - Update docs and tests when behavior or usage changes.
 - Never remove, skip, or comment out tests to make them pass; fix the underlying code.
+
+## Cursor Cloud specific instructions
+
+The VM startup update script already runs `yarn kbn bootstrap` (with Node from nvm). The notes below are runtime/startup caveats, not install steps.
+
+### Toolchain
+- Node version is pinned by `.node-version` (currently `24.18.0`) and is managed via `nvm` (nvm's `default` alias points at it). Interactive/login shells pick it up automatically via `~/.bashrc`. In a bare non-interactive shell, `node` may not be on `PATH`; source nvm first (`export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"`) or run through a login shell. Do NOT rely on `/exec-daemon/node` (that is a different, older Node).
+- Package manager is Yarn v1 (classic). Re-run `yarn kbn bootstrap` after switching branches or on dependency errors.
+
+### Services (run in separate long-lived terminals, e.g. tmux)
+- **Elasticsearch**: `node scripts/es snapshot --license trial`. Listens on `http://localhost:9200`, dev creds `elastic` / `changeme`. First run downloads the ES snapshot into `.es/` (persists). On its first start ES also downloads the ELSER ML model in the background, which briefly pins CPU near 100%.
+- **Kibana** (dev): `node scripts/kibana --dev` (add `--no-base-path` to serve at `/` on port 5601; default creds `elastic`/`changeme`). Start ES first and let it reach a steady state before/while starting Kibana.
+- Kibana is only truly ready when the log prints `Kibana is now available` — the earlier `http server running at http://localhost:5601` line appears well before the app is usable.
+
+### @kbn/optimizer gotcha (important)
+- On first `--dev` boot, `@kbn/optimizer` compiles ~223 browser bundles (several minutes). If a worker is killed mid-build (e.g. CPU/memory contention with ES's ELSER download on a cold VM), it can leave a **corrupt cache**: a later start logs `all bundles cached` yet some bundles 404 (served as `application/json`) and the UI shows **"Elastic did not load properly"** after login.
+- Fix: restart Kibana once with `node scripts/kibana --dev --no-base-path --no-cache` to force a clean full rebuild of all bundles. Clearing `data/optimize` alone is NOT enough — the per-bundle cache lives in each module's `target/public/.kbn-optimizer-cache`, which `--no-cache` bypasses.
+
+### Verifying changes
+- Lint / type-check / Jest commands are documented above (see Testing and Code Style sections). Scope them to specific files/projects; repo-wide runs are very slow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the Kibana development environment for Cursor Cloud agents, and documents durable startup/run caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

The only code/docs change in this PR is the `AGENTS.md` addition. Dependency installation is handled by the VM update script (`yarn kbn bootstrap` under nvm-managed Node), not by this PR.

## What was verified in the environment

- **Node**: installed `24.18.0` (per `.node-version`) via nvm; Yarn v1 classic.
- **Bootstrap**: `yarn kbn bootstrap` completes successfully.
- **Elasticsearch**: `node scripts/es snapshot --license trial` → cluster health GREEN on `:9200`.
- **Kibana**: `node scripts/kibana --dev --no-base-path` → `Kibana is now available` (v9.6.0) on `:5601`, all 223 optimizer bundles built.
- **Hello-world (core functionality)**: indexed a document into ES, created a Kibana **data view** saved object via the API, confirmed it persisted, and searched the document back. The data view is visible in **Stack Management → Data Views** ("Hello Kibana DV").
- **Lint**: `node scripts/eslint <file>` → no errors.
- **Jest**: `node scripts/jest <test>` → passing.

## Key gotcha documented

On a cold VM, the first `--dev` boot can crash a `@kbn/optimizer` worker (CPU contention with ES's ELSER model download), leaving a corrupt per-bundle cache. A later start then logs `all bundles cached` but serves 404 for missing bundles and the UI shows **"Elastic did not load properly"**. Fix: restart once with `--no-cache` to force a full clean rebuild (clearing `data/optimize` alone is insufficient because the cache lives in each module's `target/public/.kbn-optimizer-cache`).

## Screenshots

Kibana home after login:

[Kibana welcome home](https://cursor.com/agents/bc-99f320ee-1636-466b-951c-4510d18448d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F02_home.png)

Data view created by the hello-world task, shown in Stack Management:

[Kibana data views](https://cursor.com/agents/bc-99f320ee-1636-466b-951c-4510d18448d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F03_data_views.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f320ee-1636-466b-951c-4510d18448d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f320ee-1636-466b-951c-4510d18448d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

